### PR TITLE
New pre-execution plugin handlers, contract versioning support and bugfixes

### DIFF
--- a/dist/info/InfoHandler.js
+++ b/dist/info/InfoHandler.js
@@ -43,7 +43,8 @@ class InfoHandler {
                 const singleChain = this.chainData.chains[chainIdentifier];
                 chains[chainIdentifier] = {
                     address: singleChain.signer.getAddress(),
-                    signature: await singleChain.swapContract.getDataSignature(singleChain.signer, envelopeBuffer)
+                    signature: await singleChain.swapContract.getDataSignature(singleChain.signer, envelopeBuffer),
+                    contractVersion: singleChain.contractVersion ?? "v1"
                 };
             }
             const response = {

--- a/dist/plugins/IPlugin.d.ts
+++ b/dist/plugins/IPlugin.d.ts
@@ -1,5 +1,5 @@
 import { BitcoinRpc } from "@atomiqlabs/base";
-import { FromBtcLnRequestType, FromBtcRequestType, FromBtcTrustedRequestType, ISwapPrice, MultichainData, RequestData, SpvVaultPostQuote, SpvVaultSwap, SpvVaultSwapRequestType, SwapHandler, SwapHandlerType, ToBtcLnRequestType, ToBtcRequestType } from "..";
+import { FromBtcLnAutoSwap, FromBtcLnRequestType, FromBtcLnSwapAbs, FromBtcLnTrustedSwap, FromBtcRequestType, FromBtcSwapAbs, FromBtcTrustedRequestType, FromBtcTrustedSwap, ISwapPrice, MultichainData, RequestData, SpvVaultPostQuote, SpvVaultSwap, SpvVaultSwapRequestType, SwapHandler, SwapHandlerType, ToBtcLnRequestType, ToBtcLnSwapAbs, ToBtcRequestType, ToBtcSwapAbs } from "..";
 import { SwapHandlerSwap } from "../swaps/SwapHandlerSwap";
 import { Command } from "@atomiqlabs/server-base";
 import { FromBtcLnTrustedRequestType } from "../swaps/trusted/frombtcln_trusted/FromBtcLnTrusted";
@@ -104,6 +104,19 @@ export interface IPlugin {
         token: string;
         pricePrefetch?: Promise<bigint>;
     }): Promise<QuoteThrow | QuoteSetFees | QuoteAmountTooLow | QuoteAmountTooHigh | PluginQuote>;
+    /**
+     * Triggered when the quote is about to get executed, this means:
+     * - FROM_BTCLN - lightning network payment received and the LP is about to sign an authorization allowing the user to settle
+     * - FROM_BTC - triggered on quote request, before the final authorization is given to the user
+     * - FROM_BTCLN_TRUSTED - triggered when the LP receives the funds on the source chain and before destination funds are sent
+     * - FROM_BTC_TRUSTED - triggered when the LP receives the funds on the source chain and before destination funds are sent
+     * - FROM_BTC_SPV - triggered before LP broadcasts the co-signed swap PSBT
+     * - FROM_BTCLN_AUTO - lightning network payment received and the LP is about to offer an HTLC to the user
+     *
+     * @param swapType
+     * @param swap
+     */
+    onHandlePreFromBtcExecute?(swapType: SwapHandlerType.FROM_BTCLN | SwapHandlerType.FROM_BTC | SwapHandlerType.FROM_BTCLN_TRUSTED | SwapHandlerType.FROM_BTC_TRUSTED | SwapHandlerType.FROM_BTC_SPV | SwapHandlerType.FROM_BTCLN_AUTO, swap: FromBtcLnSwapAbs | FromBtcSwapAbs | FromBtcLnTrustedSwap | FromBtcTrustedSwap | SpvVaultSwap | FromBtcLnAutoSwap): Promise<QuoteThrow | null>;
     onHandlePreToBtcQuote?(swapType: SwapHandlerType.TO_BTCLN | SwapHandlerType.TO_BTC, request: RequestData<ToBtcLnRequestType | ToBtcRequestType>, requestedAmount: {
         input: boolean;
         amount: bigint;
@@ -128,6 +141,7 @@ export interface IPlugin {
         feePPM: bigint;
         networkFeeGetter: (amount: bigint) => Promise<bigint>;
     }): Promise<QuoteThrow | QuoteSetFees | QuoteAmountTooLow | QuoteAmountTooHigh | ToBtcPluginQuote>;
+    onHandlePreToBtcExecute?(swapType: SwapHandlerType.TO_BTCLN | SwapHandlerType.TO_BTC, swap: ToBtcLnSwapAbs | ToBtcSwapAbs): Promise<QuoteThrow | null>;
     onHandlePostedFromBtcQuote?(swapType: SwapHandlerType.FROM_BTC_SPV, request: RequestData<SpvVaultPostQuote>, swap: SpvVaultSwap): Promise<QuoteThrow | null>;
     onVaultSelection?(chainIdentifier: string, totalSats: bigint, requestedAmount: {
         amount: bigint;

--- a/dist/plugins/IPlugin.js
+++ b/dist/plugins/IPlugin.js
@@ -15,21 +15,21 @@ function isQuoteSetFees(obj) {
 }
 exports.isQuoteSetFees = isQuoteSetFees;
 function isQuoteAmountTooLow(obj) {
-    return obj != null && obj.type === "low" && typeof (obj.data) === "object" && typeof (obj.data.min) === "bigint" && typeof (obj.data.max) === "bigint";
+    return obj != null && obj.type === "low" && obj.data != null && typeof (obj.data) === "object" && typeof (obj.data.min) === "bigint" && typeof (obj.data.max) === "bigint";
 }
 exports.isQuoteAmountTooLow = isQuoteAmountTooLow;
 function isQuoteAmountTooHigh(obj) {
-    return obj != null && obj.type === "high" && typeof (obj.data) === "object" && typeof (obj.data.min) === "bigint" && typeof (obj.data.max) === "bigint";
+    return obj != null && obj.type === "high" && obj.data != null && typeof (obj.data) === "object" && typeof (obj.data.min) === "bigint" && typeof (obj.data.max) === "bigint";
 }
 exports.isQuoteAmountTooHigh = isQuoteAmountTooHigh;
 function isPluginQuote(obj) {
     return obj != null && obj.type === "success" &&
-        typeof (obj.amount) === "object" && typeof (obj.amount.input) === "boolean" && typeof (obj.amount.amount) === "bigint" &&
-        typeof (obj.swapFee) === "object" && typeof (obj.swapFee.inInputTokens) === "bigint" && typeof (obj.swapFee.inOutputTokens) === "bigint";
+        obj.amount != null && typeof (obj.amount) === "object" && typeof (obj.amount.input) === "boolean" && typeof (obj.amount.amount) === "bigint" &&
+        obj.swapFee != null && typeof (obj.swapFee) === "object" && typeof (obj.swapFee.inInputTokens) === "bigint" && typeof (obj.swapFee.inOutputTokens) === "bigint";
 }
 exports.isPluginQuote = isPluginQuote;
 function isToBtcPluginQuote(obj) {
-    return obj != null && typeof (obj.networkFee) === "object" && typeof (obj.networkFee.inInputTokens) === "bigint" && typeof (obj.networkFee.inOutputTokens) === "bigint" &&
+    return obj != null && obj.networkFee != null && typeof (obj.networkFee) === "object" && typeof (obj.networkFee.inInputTokens) === "bigint" && typeof (obj.networkFee.inOutputTokens) === "bigint" &&
         isPluginQuote(obj);
 }
 exports.isToBtcPluginQuote = isToBtcPluginQuote;

--- a/dist/plugins/IPlugin.js
+++ b/dist/plugins/IPlugin.js
@@ -2,11 +2,12 @@
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.isToBtcPluginQuote = exports.isPluginQuote = exports.isQuoteAmountTooHigh = exports.isQuoteAmountTooLow = exports.isQuoteSetFees = exports.isQuoteThrow = void 0;
 function isQuoteThrow(obj) {
-    return obj.type === "throw" && typeof (obj.message) === "string";
+    return obj != null && obj.type === "throw" && typeof (obj.message) === "string";
 }
 exports.isQuoteThrow = isQuoteThrow;
 function isQuoteSetFees(obj) {
-    return obj.type === "fees" &&
+    return obj != null &&
+        obj.type === "fees" &&
         (obj.baseFee == null || typeof (obj.baseFee) === "bigint") &&
         (obj.feePPM == null || typeof (obj.feePPM) === "bigint") &&
         (obj.securityDepositApyPPM == null || typeof (obj.securityDepositApyPPM) === "bigint") &&
@@ -14,21 +15,21 @@ function isQuoteSetFees(obj) {
 }
 exports.isQuoteSetFees = isQuoteSetFees;
 function isQuoteAmountTooLow(obj) {
-    return obj.type === "low" && typeof (obj.data) === "object" && typeof (obj.data.min) === "bigint" && typeof (obj.data.max) === "bigint";
+    return obj != null && obj.type === "low" && typeof (obj.data) === "object" && typeof (obj.data.min) === "bigint" && typeof (obj.data.max) === "bigint";
 }
 exports.isQuoteAmountTooLow = isQuoteAmountTooLow;
 function isQuoteAmountTooHigh(obj) {
-    return obj.type === "high" && typeof (obj.data) === "object" && typeof (obj.data.min) === "bigint" && typeof (obj.data.max) === "bigint";
+    return obj != null && obj.type === "high" && typeof (obj.data) === "object" && typeof (obj.data.min) === "bigint" && typeof (obj.data.max) === "bigint";
 }
 exports.isQuoteAmountTooHigh = isQuoteAmountTooHigh;
 function isPluginQuote(obj) {
-    return obj.type === "success" &&
+    return obj != null && obj.type === "success" &&
         typeof (obj.amount) === "object" && typeof (obj.amount.input) === "boolean" && typeof (obj.amount.amount) === "bigint" &&
         typeof (obj.swapFee) === "object" && typeof (obj.swapFee.inInputTokens) === "bigint" && typeof (obj.swapFee.inOutputTokens) === "bigint";
 }
 exports.isPluginQuote = isPluginQuote;
 function isToBtcPluginQuote(obj) {
-    return typeof (obj.networkFee) === "object" && typeof (obj.networkFee.inInputTokens) === "bigint" && typeof (obj.networkFee.inOutputTokens) === "bigint" &&
+    return obj != null && typeof (obj.networkFee) === "object" && typeof (obj.networkFee.inInputTokens) === "bigint" && typeof (obj.networkFee.inOutputTokens) === "bigint" &&
         isPluginQuote(obj);
 }
 exports.isToBtcPluginQuote = isToBtcPluginQuote;

--- a/dist/plugins/PluginManager.d.ts
+++ b/dist/plugins/PluginManager.d.ts
@@ -1,6 +1,6 @@
 import { BitcoinRpc, SwapData } from "@atomiqlabs/base";
 import { IPlugin, PluginQuote, QuoteAmountTooHigh, QuoteAmountTooLow, QuoteSetFees, QuoteThrow, ToBtcPluginQuote } from "./IPlugin";
-import { FromBtcLnRequestType, FromBtcRequestType, FromBtcTrustedRequestType, ISwapPrice, MultichainData, RequestData, SpvVaultPostQuote, SpvVaultSwap, SpvVaultSwapRequestType, SwapHandler, SwapHandlerType, ToBtcLnRequestType, ToBtcRequestType } from "..";
+import { FromBtcLnAutoSwap, FromBtcLnRequestType, FromBtcLnSwapAbs, FromBtcLnTrustedSwap, FromBtcRequestType, FromBtcSwapAbs, FromBtcTrustedRequestType, FromBtcTrustedSwap, ISwapPrice, MultichainData, RequestData, SpvVaultPostQuote, SpvVaultSwap, SpvVaultSwapRequestType, SwapHandler, SwapHandlerType, ToBtcLnRequestType, ToBtcLnSwapAbs, ToBtcRequestType, ToBtcSwapAbs } from "..";
 import { SwapHandlerSwap } from "../swaps/SwapHandlerSwap";
 import { FromBtcLnTrustedRequestType } from "../swaps/trusted/frombtcln_trusted/FromBtcLnTrusted";
 import { IBitcoinWallet } from "../wallets/IBitcoinWallet";
@@ -73,6 +73,7 @@ export declare class PluginManager {
         amount: bigint;
         token: string;
     }): Promise<QuoteThrow | QuoteSetFees | QuoteAmountTooLow | QuoteAmountTooHigh>;
+    static onHandlePreFromBtcExecute(swapType: SwapHandlerType.FROM_BTCLN | SwapHandlerType.FROM_BTC | SwapHandlerType.FROM_BTCLN_TRUSTED | SwapHandlerType.FROM_BTC_TRUSTED | SwapHandlerType.FROM_BTC_SPV | SwapHandlerType.FROM_BTCLN_AUTO, swap: FromBtcLnSwapAbs | FromBtcSwapAbs | FromBtcLnTrustedSwap | FromBtcTrustedSwap | SpvVaultSwap | FromBtcLnAutoSwap): Promise<QuoteThrow | null>;
     static onHandlePostToBtcQuote<T extends {
         networkFee: bigint;
     }>(swapType: SwapHandlerType.TO_BTCLN | SwapHandlerType.TO_BTC, request: RequestData<ToBtcLnRequestType | ToBtcRequestType>, requestedAmount: {
@@ -101,6 +102,7 @@ export declare class PluginManager {
         baseFeeInBtc: bigint;
         feePPM: bigint;
     }): Promise<QuoteThrow | QuoteSetFees | QuoteAmountTooLow | QuoteAmountTooHigh>;
+    static onHandlePreToBtcExecute(swapType: SwapHandlerType.TO_BTCLN | SwapHandlerType.TO_BTC, swap: ToBtcLnSwapAbs | ToBtcSwapAbs): Promise<QuoteThrow | null>;
     static onHandlePostedFromBtcQuote(swapType: SwapHandlerType.FROM_BTC_SPV, request: RequestData<SpvVaultPostQuote>, swap: SpvVaultSwap): Promise<QuoteThrow | null>;
     static onVaultSelection(chainIdentifier: string, totalSats: bigint, requestedAmount: {
         amount: bigint;

--- a/dist/plugins/PluginManager.js
+++ b/dist/plugins/PluginManager.js
@@ -152,6 +152,21 @@ class PluginManager {
         }
         return null;
     }
+    static async onHandlePreFromBtcExecute(swapType, swap) {
+        for (let plugin of PluginManager.plugins.values()) {
+            try {
+                if (plugin.onHandlePreFromBtcExecute != null) {
+                    const result = await plugin.onHandlePreFromBtcExecute(swapType, swap);
+                    if (result != null && (0, IPlugin_1.isQuoteThrow)(result))
+                        return result;
+                }
+            }
+            catch (e) {
+                pluginLogger.error(plugin, "onHandlePreFromBtcExecute(): plugin error", e);
+            }
+        }
+        return null;
+    }
     static async onHandlePostToBtcQuote(swapType, request, requestedAmount, chainIdentifier, constraints, fees) {
         for (let plugin of PluginManager.plugins.values()) {
             try {
@@ -210,6 +225,21 @@ class PluginManager {
             }
             catch (e) {
                 pluginLogger.error(plugin, "onSwapRequestToBtcLn(): plugin error", e);
+            }
+        }
+        return null;
+    }
+    static async onHandlePreToBtcExecute(swapType, swap) {
+        for (let plugin of PluginManager.plugins.values()) {
+            try {
+                if (plugin.onHandlePreToBtcExecute != null) {
+                    const result = await plugin.onHandlePreToBtcExecute(swapType, swap);
+                    if (result != null && (0, IPlugin_1.isQuoteThrow)(result))
+                        return result;
+                }
+            }
+            catch (e) {
+                pluginLogger.error(plugin, "onHandlePreToBtcExecute(): plugin error", e);
             }
         }
         return null;

--- a/dist/swaps/SwapHandler.d.ts
+++ b/dist/swaps/SwapHandler.d.ts
@@ -59,6 +59,7 @@ export type ChainData<T extends ChainType = ChainType> = {
     };
     allowedDepositTokens?: string[];
     btcRelay?: T["BtcRelay"];
+    contractVersion?: string;
 };
 export type RequestData<T> = {
     chainIdentifier: string;

--- a/dist/swaps/SwapHandlerSwap.d.ts
+++ b/dist/swaps/SwapHandlerSwap.d.ts
@@ -76,4 +76,5 @@ export declare abstract class SwapHandlerSwap<S = any> extends Lockable implemen
         inInputToken: bigint;
         inOutputToken: bigint;
     };
+    abstract getDestinationAddress(): string;
 }

--- a/dist/swaps/escrow/frombtc_abstract/FromBtcAbs.js
+++ b/dist/swaps/escrow/frombtc_abstract/FromBtcAbs.js
@@ -10,6 +10,7 @@ const PluginManager_1 = require("../../../plugins/PluginManager");
 const SchemaVerifier_1 = require("../../../utils/paramcoders/SchemaVerifier");
 const ServerParamDecoder_1 = require("../../../utils/paramcoders/server/ServerParamDecoder");
 const FromBtcBaseSwapHandler_1 = require("../FromBtcBaseSwapHandler");
+const IPlugin_1 = require("../../../plugins/IPlugin");
 /**
  * Swap handler handling from BTC swaps using PTLCs (proof-time locked contracts) and btc relay (on-chain bitcoin SPV)
  */
@@ -281,6 +282,12 @@ class FromBtcAbs extends FromBtcBaseSwapHandler_1.FromBtcBaseSwapHandler {
             createdSwap.timeout = sigData.timeout;
             createdSwap.signature = sigData.signature;
             createdSwap.feeRate = sigData.feeRate;
+            const pluginCheckResult = await PluginManager_1.PluginManager.onHandlePreFromBtcExecute(SwapHandler_1.SwapHandlerType.FROM_BTC, createdSwap);
+            if ((0, IPlugin_1.isQuoteThrow)(pluginCheckResult))
+                throw {
+                    code: 29999,
+                    msg: pluginCheckResult.message
+                };
             await PluginManager_1.PluginManager.swapCreate(createdSwap);
             await this.saveSwapData(createdSwap);
             this.swapLogger.info(createdSwap, "REST: /getAddress: Created swap address: " + receiveAddress + " amount: " + amountBD.toString(10));

--- a/dist/swaps/escrow/frombtc_abstract/FromBtcSwapAbs.d.ts
+++ b/dist/swaps/escrow/frombtc_abstract/FromBtcSwapAbs.d.ts
@@ -18,4 +18,5 @@ export declare class FromBtcSwapAbs<T extends SwapData = SwapData> extends FromB
     isFailed(): boolean;
     isSuccess(): boolean;
     getTotalInputAmount(): bigint;
+    getDestinationAddress(): string;
 }

--- a/dist/swaps/escrow/frombtc_abstract/FromBtcSwapAbs.js
+++ b/dist/swaps/escrow/frombtc_abstract/FromBtcSwapAbs.js
@@ -46,5 +46,8 @@ class FromBtcSwapAbs extends FromBtcBaseSwap_1.FromBtcBaseSwap {
     getTotalInputAmount() {
         return this.amount;
     }
+    getDestinationAddress() {
+        return this.data.getClaimer();
+    }
 }
 exports.FromBtcSwapAbs = FromBtcSwapAbs;

--- a/dist/swaps/escrow/frombtcln_abstract/FromBtcLnAbs.js
+++ b/dist/swaps/escrow/frombtcln_abstract/FromBtcLnAbs.js
@@ -11,6 +11,7 @@ const SchemaVerifier_1 = require("../../../utils/paramcoders/SchemaVerifier");
 const ServerParamDecoder_1 = require("../../../utils/paramcoders/server/ServerParamDecoder");
 const FromBtcBaseSwapHandler_1 = require("../FromBtcBaseSwapHandler");
 const LightningAssertions_1 = require("../../assertions/LightningAssertions");
+const IPlugin_1 = require("../../../plugins/IPlugin");
 /**
  * Swap handler handling from BTCLN swaps using submarine swaps
  */
@@ -291,6 +292,18 @@ class FromBtcLnAbs extends FromBtcBaseSwapHandler_1.FromBtcBaseSwapHandler {
         //No need to check abortController anymore since all pending promises are resolved by now
         if (invoiceData.metadata != null)
             invoiceData.metadata.times.htlcSwapSigned = Date.now();
+        const pluginCheckResult = await PluginManager_1.PluginManager.onHandlePreFromBtcExecute(SwapHandler_1.SwapHandlerType.FROM_BTCLN, invoiceData);
+        if ((0, IPlugin_1.isQuoteThrow)(pluginCheckResult)) {
+            const error = {
+                code: 29999,
+                msg: pluginCheckResult.message
+            };
+            if (invoiceData.metadata != null)
+                invoiceData.metadata.htlcReceiveError = error;
+            if (invoiceData.state === FromBtcLnSwapAbs_1.FromBtcLnSwapState.CREATED)
+                await this.cancelSwapAndInvoice(invoiceData);
+            throw error;
+        }
         //Important to prevent race condition and issuing 2 signed init messages at the same time
         if (invoiceData.state === FromBtcLnSwapAbs_1.FromBtcLnSwapState.CREATED) {
             //Re-check right before signing
@@ -662,17 +675,24 @@ class FromBtcLnAbs extends FromBtcBaseSwapHandler_1.FromBtcBaseSwapHandler {
                     code: 10004,
                     msg: "Invoice already committed"
                 };
-            res.status(200).json({
-                code: 10000,
-                msg: "Success",
-                data: {
-                    address: signer.getAddress(),
-                    data: swap.data.serialize(),
-                    prefix: swap.prefix,
-                    timeout: swap.timeout,
-                    signature: swap.signature
-                }
-            });
+            if (swap.state === FromBtcLnSwapAbs_1.FromBtcLnSwapState.CLAIMED)
+                throw {
+                    _httpStatus: 200,
+                    code: 10005,
+                    msg: "Invoice already committed & claimed"
+                };
+            if (swap.state === FromBtcLnSwapAbs_1.FromBtcLnSwapState.RECEIVED)
+                res.status(200).json({
+                    code: 10000,
+                    msg: "Success",
+                    data: {
+                        address: signer.getAddress(),
+                        data: swap.data.serialize(),
+                        prefix: swap.prefix,
+                        timeout: swap.timeout,
+                        signature: swap.signature
+                    }
+                });
         });
         restServer.post(this.path + "/getInvoicePaymentAuth", getInvoicePaymentAuth);
         restServer.get(this.path + "/getInvoicePaymentAuth", getInvoicePaymentAuth);

--- a/dist/swaps/escrow/frombtcln_abstract/FromBtcLnSwapAbs.d.ts
+++ b/dist/swaps/escrow/frombtcln_abstract/FromBtcLnSwapAbs.d.ts
@@ -30,4 +30,5 @@ export declare class FromBtcLnSwapAbs<T extends SwapData = SwapData> extends Fro
     isInitiated(): boolean;
     isFailed(): boolean;
     isSuccess(): boolean;
+    getDestinationAddress(): string;
 }

--- a/dist/swaps/escrow/frombtcln_abstract/FromBtcLnSwapAbs.js
+++ b/dist/swaps/escrow/frombtcln_abstract/FromBtcLnSwapAbs.js
@@ -87,5 +87,8 @@ class FromBtcLnSwapAbs extends FromBtcBaseSwap_1.FromBtcBaseSwap {
     isSuccess() {
         return this.state === FromBtcLnSwapState.SETTLED;
     }
+    getDestinationAddress() {
+        return this.claimer;
+    }
 }
 exports.FromBtcLnSwapAbs = FromBtcLnSwapAbs;

--- a/dist/swaps/escrow/frombtcln_autoinit/FromBtcLnAuto.js
+++ b/dist/swaps/escrow/frombtcln_autoinit/FromBtcLnAuto.js
@@ -680,8 +680,7 @@ class FromBtcLnAuto extends FromBtcBaseSwapHandler_1.FromBtcBaseSwapHandler {
                     code: 10001,
                     msg: "Invoice expired/canceled"
                 };
-            if (swap.state === FromBtcLnAutoSwap_1.FromBtcLnAutoSwapState.RECEIVED ||
-                swap.state === FromBtcLnAutoSwap_1.FromBtcLnAutoSwapState.TXS_SENT ||
+            if (swap.state === FromBtcLnAutoSwap_1.FromBtcLnAutoSwapState.TXS_SENT ||
                 swap.state === FromBtcLnAutoSwap_1.FromBtcLnAutoSwapState.COMMITED) {
                 res.status(200).json({
                     code: 10000,

--- a/dist/swaps/escrow/frombtcln_autoinit/FromBtcLnAuto.js
+++ b/dist/swaps/escrow/frombtcln_autoinit/FromBtcLnAuto.js
@@ -11,6 +11,7 @@ const SchemaVerifier_1 = require("../../../utils/paramcoders/SchemaVerifier");
 const ServerParamDecoder_1 = require("../../../utils/paramcoders/server/ServerParamDecoder");
 const FromBtcBaseSwapHandler_1 = require("../FromBtcBaseSwapHandler");
 const LightningAssertions_1 = require("../../assertions/LightningAssertions");
+const IPlugin_1 = require("../../../plugins/IPlugin");
 /**
  * Swap handler handling from BTCLN swaps using submarine swaps
  */
@@ -340,6 +341,18 @@ class FromBtcLnAuto extends FromBtcBaseSwapHandler_1.FromBtcBaseSwapHandler {
             timeout: invoiceData.timeout,
             signature: invoiceData.signature
         }, true);
+        const pluginCheckResult = await PluginManager_1.PluginManager.onHandlePreFromBtcExecute(SwapHandler_1.SwapHandlerType.FROM_BTCLN_AUTO, invoiceData);
+        if ((0, IPlugin_1.isQuoteThrow)(pluginCheckResult)) {
+            const error = {
+                code: 29999,
+                msg: pluginCheckResult.message
+            };
+            if (invoiceData.metadata != null)
+                invoiceData.metadata.htlcOfferError = error;
+            if (invoiceData.state === FromBtcLnAutoSwap_1.FromBtcLnAutoSwapState.RECEIVED)
+                await this.cancelSwapAndInvoice(invoiceData);
+            throw error;
+        }
         if (invoiceData.state === FromBtcLnAutoSwap_1.FromBtcLnAutoSwapState.RECEIVED) {
             //Re-check the current HTLC count
             try {

--- a/dist/swaps/escrow/frombtcln_autoinit/FromBtcLnAutoSwap.d.ts
+++ b/dist/swaps/escrow/frombtcln_autoinit/FromBtcLnAutoSwap.d.ts
@@ -52,4 +52,5 @@ export declare class FromBtcLnAutoSwap<T extends SwapData = SwapData> extends Fr
     isInitiated(): boolean;
     isFailed(): boolean;
     isSuccess(): boolean;
+    getDestinationAddress(): string;
 }

--- a/dist/swaps/escrow/frombtcln_autoinit/FromBtcLnAutoSwap.js
+++ b/dist/swaps/escrow/frombtcln_autoinit/FromBtcLnAutoSwap.js
@@ -116,5 +116,8 @@ class FromBtcLnAutoSwap extends FromBtcBaseSwap_1.FromBtcBaseSwap {
     isSuccess() {
         return this.state === FromBtcLnAutoSwapState.SETTLED;
     }
+    getDestinationAddress() {
+        return this.claimer;
+    }
 }
 exports.FromBtcLnAutoSwap = FromBtcLnAutoSwap;

--- a/dist/swaps/escrow/tobtc_abstract/ToBtcAbs.js
+++ b/dist/swaps/escrow/tobtc_abstract/ToBtcAbs.js
@@ -11,6 +11,7 @@ const SchemaVerifier_1 = require("../../../utils/paramcoders/SchemaVerifier");
 const ServerParamDecoder_1 = require("../../../utils/paramcoders/server/ServerParamDecoder");
 const ToBtcBaseSwapHandler_1 = require("../ToBtcBaseSwapHandler");
 const BitcoinUtils_1 = require("../../../utils/BitcoinUtils");
+const IPlugin_1 = require("../../../plugins/IPlugin");
 const OUTPUT_SCRIPT_MAX_LENGTH = 200;
 const MAX_PARALLEL_TX_PROCESSED = 10;
 /**
@@ -346,9 +347,29 @@ class ToBtcAbs extends ToBtcBaseSwapHandler_1.ToBtcBaseSwapHandler {
             await this.saveSwapData(swap);
         }
         if (swap.state === ToBtcSwapAbs_1.ToBtcSwapState.COMMITED) {
-            const unlock = swap.lock(60);
+            const unlock = swap.lock(Infinity);
             if (unlock == null)
                 return;
+            const pluginCheckResult = await PluginManager_1.PluginManager.onHandlePreToBtcExecute(SwapHandler_1.SwapHandlerType.TO_BTC, swap);
+            if ((0, IPlugin_1.isQuoteThrow)(pluginCheckResult)) {
+                const error = {
+                    code: 29999,
+                    msg: pluginCheckResult.message
+                };
+                this.swapLogger.error(swap, "processInitialized(state=COMMITED): setting state to NON_PAYABLE due to send bitcoin payment error", error);
+                if (swap.metadata != null)
+                    swap.metadata.payError = error;
+                if (swap.state === ToBtcSwapAbs_1.ToBtcSwapState.COMMITED) {
+                    await swap.setState(ToBtcSwapAbs_1.ToBtcSwapState.NON_PAYABLE);
+                    await this.saveSwapData(swap);
+                }
+                unlock();
+                return;
+            }
+            if (swap.state !== ToBtcSwapAbs_1.ToBtcSwapState.COMMITED) {
+                unlock();
+                return;
+            }
             this.swapLogger.debug(swap, "processInitialized(state=COMMITED): sending bitcoin transaction, address: " + swap.address);
             try {
                 await this.sendBitcoinPayment(swap);
@@ -367,7 +388,9 @@ class ToBtcAbs extends ToBtcBaseSwapHandler_1.ToBtcBaseSwapHandler {
                     throw e;
                 }
             }
-            unlock();
+            finally {
+                unlock();
+            }
         }
         if (swap.state === ToBtcSwapAbs_1.ToBtcSwapState.NON_PAYABLE)
             return;

--- a/dist/swaps/escrow/tobtc_abstract/ToBtcAbs.js
+++ b/dist/swaps/escrow/tobtc_abstract/ToBtcAbs.js
@@ -359,11 +359,11 @@ class ToBtcAbs extends ToBtcBaseSwapHandler_1.ToBtcBaseSwapHandler {
                 this.swapLogger.error(swap, "processInitialized(state=COMMITED): setting state to NON_PAYABLE due to send bitcoin payment error", error);
                 if (swap.metadata != null)
                     swap.metadata.payError = error;
+                unlock();
                 if (swap.state === ToBtcSwapAbs_1.ToBtcSwapState.COMMITED) {
                     await swap.setState(ToBtcSwapAbs_1.ToBtcSwapState.NON_PAYABLE);
                     await this.saveSwapData(swap);
                 }
-                unlock();
                 return;
             }
             if (swap.state !== ToBtcSwapAbs_1.ToBtcSwapState.COMMITED) {

--- a/dist/swaps/escrow/tobtc_abstract/ToBtcSwapAbs.d.ts
+++ b/dist/swaps/escrow/tobtc_abstract/ToBtcSwapAbs.d.ts
@@ -25,4 +25,5 @@ export declare class ToBtcSwapAbs<T extends SwapData = SwapData> extends ToBtcBa
     isInitiated(): boolean;
     isFailed(): boolean;
     isSuccess(): boolean;
+    getDestinationAddress(): string;
 }

--- a/dist/swaps/escrow/tobtc_abstract/ToBtcSwapAbs.js
+++ b/dist/swaps/escrow/tobtc_abstract/ToBtcSwapAbs.js
@@ -60,5 +60,8 @@ class ToBtcSwapAbs extends ToBtcBaseSwap_1.ToBtcBaseSwap {
     isSuccess() {
         return this.state === ToBtcSwapState.CLAIMED;
     }
+    getDestinationAddress() {
+        return this.address;
+    }
 }
 exports.ToBtcSwapAbs = ToBtcSwapAbs;

--- a/dist/swaps/escrow/tobtcln_abstract/ToBtcLnAbs.js
+++ b/dist/swaps/escrow/tobtcln_abstract/ToBtcLnAbs.js
@@ -12,6 +12,7 @@ const SchemaVerifier_1 = require("../../../utils/paramcoders/SchemaVerifier");
 const ToBtcBaseSwapHandler_1 = require("../ToBtcBaseSwapHandler");
 const ILightningWallet_1 = require("../../../wallets/ILightningWallet");
 const LightningAssertions_1 = require("../../assertions/LightningAssertions");
+const IPlugin_1 = require("../../../plugins/IPlugin");
 /**
  * Swap handler handling to BTCLN swaps using submarine swaps
  */
@@ -229,6 +230,15 @@ class ToBtcLnAbs extends ToBtcBaseSwapHandler_1.ToBtcBaseSwapHandler {
             " maxFee: " + maxFee.toString(10) +
             " invoice: " + swap.pr);
         const blockHeight = await this.lightning.getBlockheight();
+        const pluginCheckResult = await PluginManager_1.PluginManager.onHandlePreToBtcExecute(SwapHandler_1.SwapHandlerType.TO_BTCLN, swap);
+        if ((0, IPlugin_1.isQuoteThrow)(pluginCheckResult)) {
+            throw {
+                code: 29999,
+                msg: pluginCheckResult.message
+            };
+        }
+        if (swap.state !== ToBtcLnSwapAbs_1.ToBtcLnSwapState.COMMITED)
+            return false;
         swap.payInitiated = true;
         await this.saveSwapData(swap);
         try {
@@ -249,6 +259,7 @@ class ToBtcLnAbs extends ToBtcBaseSwapHandler_1.ToBtcBaseSwapHandler {
         }
         if (swap.metadata != null)
             swap.metadata.times.payComplete = Date.now();
+        return true;
     }
     /**
      * Begins a lightning network payment attempt, if not attempted already
@@ -303,7 +314,8 @@ class ToBtcLnAbs extends ToBtcBaseSwapHandler_1.ToBtcBaseSwapHandler {
             await swap.setState(ToBtcLnSwapAbs_1.ToBtcLnSwapState.COMMITED);
             await this.saveSwapData(swap);
             try {
-                await this.sendLightningPayment(swap);
+                if (!await this.sendLightningPayment(swap))
+                    return;
             }
             catch (e) {
                 this.swapLogger.error(swap, "processInitialized(): lightning payment error", e);

--- a/dist/swaps/escrow/tobtcln_abstract/ToBtcLnSwapAbs.d.ts
+++ b/dist/swaps/escrow/tobtcln_abstract/ToBtcLnSwapAbs.d.ts
@@ -21,4 +21,5 @@ export declare class ToBtcLnSwapAbs<T extends SwapData = SwapData> extends ToBtc
     isInitiated(): boolean;
     isFailed(): boolean;
     isSuccess(): boolean;
+    getDestinationAddress(): string;
 }

--- a/dist/swaps/escrow/tobtcln_abstract/ToBtcLnSwapAbs.js
+++ b/dist/swaps/escrow/tobtcln_abstract/ToBtcLnSwapAbs.js
@@ -54,5 +54,8 @@ class ToBtcLnSwapAbs extends ToBtcBaseSwap_1.ToBtcBaseSwap {
     isSuccess() {
         return this.state === ToBtcLnSwapState.CLAIMED;
     }
+    getDestinationAddress() {
+        return this.pr;
+    }
 }
 exports.ToBtcLnSwapAbs = ToBtcLnSwapAbs;

--- a/dist/swaps/spv_vault_swap/SpvVaultSwap.d.ts
+++ b/dist/swaps/spv_vault_swap/SpvVaultSwap.d.ts
@@ -65,4 +65,5 @@ export declare class SpvVaultSwap extends SwapHandlerSwap<SpvVaultSwapState> {
     isFailed(): boolean;
     isInitiated(): boolean;
     isSuccess(): boolean;
+    getDestinationAddress(): string;
 }

--- a/dist/swaps/spv_vault_swap/SpvVaultSwap.js
+++ b/dist/swaps/spv_vault_swap/SpvVaultSwap.js
@@ -154,5 +154,8 @@ class SpvVaultSwap extends SwapHandlerSwap_1.SwapHandlerSwap {
     isSuccess() {
         return this.state === SpvVaultSwapState.CLAIMED;
     }
+    getDestinationAddress() {
+        return this.recipient;
+    }
 }
 exports.SpvVaultSwap = SpvVaultSwap;

--- a/dist/swaps/spv_vault_swap/SpvVaultSwapHandler.js
+++ b/dist/swaps/spv_vault_swap/SpvVaultSwapHandler.js
@@ -14,6 +14,7 @@ const btc_signer_1 = require("@scure/btc-signer");
 const SpvVaults_1 = require("./SpvVaults");
 const BitcoinUtils_1 = require("../../utils/BitcoinUtils");
 const AmountAssertions_1 = require("../assertions/AmountAssertions");
+const IPlugin_1 = require("../../plugins/IPlugin");
 const TX_MAX_VSIZE = 16 * 1024;
 class SpvVaultSwapHandler extends SwapHandler_1.SwapHandler {
     constructor(storageDirectory, vaultStorage, path, chainsData, swapPricing, bitcoin, bitcoinRpc, spvVaultSigner, config) {
@@ -452,7 +453,7 @@ class SpvVaultSwapHandler extends SwapHandler_1.SwapHandler {
             if (swap.vaultUtxo !== vault.getLatestUtxo()) {
                 throw {
                     code: 20510,
-                    msg: "Vault UTXO already spent, please try again!"
+                    msg: "Vault UTXO already spent, please get another quote and try again!"
                 };
             }
             //Create abortController for parallel prefetches
@@ -475,11 +476,22 @@ class SpvVaultSwapHandler extends SwapHandler_1.SwapHandler {
                     code: 20516,
                     msg: "Bitcoin transaction size too large, maximum: " + TX_MAX_VSIZE + " actual: " + txVsize
                 };
+            const pluginCheckResult = await PluginManager_1.PluginManager.onHandlePreFromBtcExecute(SwapHandler_1.SwapHandlerType.FROM_BTC_SPV, swap);
+            if ((0, IPlugin_1.isQuoteThrow)(pluginCheckResult)) {
+                const error = {
+                    code: 29999,
+                    msg: pluginCheckResult.message
+                };
+                if (swap.metadata != null)
+                    swap.metadata.postQuoteError = error;
+                await this.removeSwapData(swap, SpvVaultSwap_1.SpvVaultSwapState.FAILED);
+                throw error;
+            }
             await this.Vaults.checkVaultReplacedTransactions(vault, true);
             if (swap.vaultUtxo !== vault.getLatestUtxo()) {
                 throw {
                     code: 20510,
-                    msg: "Vault UTXO already spent, please try again!"
+                    msg: "Vault UTXO already spent, please get another quote and try again!"
                 };
             }
             try {

--- a/dist/swaps/trusted/frombtc_trusted/FromBtcTrusted.js
+++ b/dist/swaps/trusted/frombtc_trusted/FromBtcTrusted.js
@@ -7,6 +7,7 @@ const PluginManager_1 = require("../../../plugins/PluginManager");
 const Utils_1 = require("../../../utils/Utils");
 const SchemaVerifier_1 = require("../../../utils/paramcoders/SchemaVerifier");
 const FromBtcAmountAssertions_1 = require("../../assertions/FromBtcAmountAssertions");
+const IPlugin_1 = require("../../../plugins/IPlugin");
 class FromBtcTrusted extends SwapHandler_1.SwapHandler {
     constructor(storageDirectory, path, chains, bitcoin, swapPricing, bitcoinRpc, config) {
         var _a;
@@ -30,42 +31,45 @@ class FromBtcTrusted extends SwapHandler_1.SwapHandler {
         })));
     }
     async refundSwap(swap) {
-        if (swap.refundAddress == null) {
-            if (swap.state !== FromBtcTrustedSwap_1.FromBtcTrustedSwapState.REFUNDABLE) {
-                await swap.setState(FromBtcTrustedSwap_1.FromBtcTrustedSwapState.REFUNDABLE);
-                await this.storageManager.saveData(swap.getIdentifierHash(), swap.getSequence(), swap);
-            }
-            return;
+        if (swap.state !== FromBtcTrustedSwap_1.FromBtcTrustedSwapState.REFUNDABLE) {
+            await swap.setState(FromBtcTrustedSwap_1.FromBtcTrustedSwapState.REFUNDABLE);
+            await this.storageManager.saveData(swap.getIdentifierHash(), swap.getSequence(), swap);
         }
-        let unlock = swap.lock(30 * 1000);
+        if (swap.refundAddress == null)
+            return;
+        let unlock = swap.lock(Infinity);
         if (unlock == null)
             return;
-        const feeRate = await this.bitcoin.getFeeRate();
-        const ourOutput = swap.btcTx.outs[swap.vout];
-        const resp = await this.bitcoin.drainAll(swap.refundAddress, [{
-                type: this.bitcoin.getAddressType(),
-                confirmations: swap.btcTx.confirmations,
-                outputScript: Buffer.from(ourOutput.scriptPubKey.hex, "hex"),
-                value: ourOutput.value,
-                txId: swap.btcTx.txid,
-                vout: swap.vout
-            }], feeRate);
-        if (resp == null) {
-            this.swapLogger.error(swap, "refundSwap(): cannot refund swap because of dust limit, txId: " + swap.txId);
-            unlock();
-            return;
+        try {
+            const feeRate = await this.bitcoin.getFeeRate();
+            const ourOutput = swap.btcTx.outs[swap.vout];
+            const resp = await this.bitcoin.drainAll(swap.refundAddress, [{
+                    type: this.bitcoin.getAddressType(),
+                    confirmations: swap.btcTx.confirmations,
+                    outputScript: Buffer.from(ourOutput.scriptPubKey.hex, "hex"),
+                    value: ourOutput.value,
+                    txId: swap.btcTx.txid,
+                    vout: swap.vout
+                }], feeRate);
+            if (resp == null) {
+                this.swapLogger.error(swap, "refundSwap(): cannot refund swap because of dust limit, txId: " + swap.txId);
+                unlock();
+                return;
+            }
+            if (swap.metadata != null)
+                swap.metadata.times.refundSignPSBT = Date.now();
+            this.swapLogger.debug(swap, "refundSwap(): signed raw transaction: " + resp.raw);
+            const refundTxId = resp.txId;
+            swap.refundTxId = refundTxId;
+            //Send the refund TX
+            await this.bitcoin.sendRawTransaction(resp.raw);
+            this.swapLogger.debug(swap, "refundSwap(): sent refund transaction: " + refundTxId);
+            this.refundedSwaps.set(swap.getIdentifierHash(), refundTxId);
+            await this.removeSwapData(swap, FromBtcTrustedSwap_1.FromBtcTrustedSwapState.REFUNDED);
         }
-        if (swap.metadata != null)
-            swap.metadata.times.refundSignPSBT = Date.now();
-        this.swapLogger.debug(swap, "refundSwap(): signed raw transaction: " + resp.raw);
-        const refundTxId = resp.txId;
-        swap.refundTxId = refundTxId;
-        //Send the refund TX
-        await this.bitcoin.sendRawTransaction(resp.raw);
-        this.swapLogger.debug(swap, "refundSwap(): sent refund transaction: " + refundTxId);
-        this.refundedSwaps.set(swap.getIdentifierHash(), refundTxId);
-        await this.removeSwapData(swap, FromBtcTrustedSwap_1.FromBtcTrustedSwapState.REFUNDED);
-        unlock();
+        finally {
+            unlock();
+        }
     }
     async burn(swap) {
         const ourOutput = swap.btcTx.outs[swap.vout];
@@ -241,10 +245,21 @@ class FromBtcTrusted extends SwapHandler_1.SwapHandler {
             }
             if (swap.state !== FromBtcTrustedSwap_1.FromBtcTrustedSwapState.BTC_CONFIRMED)
                 return;
+            const txns = await chainInterface.txsTransfer(signer.getAddress(), swap.token, swap.adjustedOutput, swap.dstAddress);
             let unlock = swap.lock(30 * 1000);
             if (unlock == null)
                 return;
-            const txns = await chainInterface.txsTransfer(signer.getAddress(), swap.token, swap.adjustedOutput, swap.dstAddress);
+            const pluginCheckResult = await PluginManager_1.PluginManager.onHandlePreFromBtcExecute(SwapHandler_1.SwapHandlerType.FROM_BTC_TRUSTED, swap);
+            if ((0, IPlugin_1.isQuoteThrow)(pluginCheckResult)) {
+                this.swapLogger.error(swap, "processPastSwap(): Error, got negative response from plugin: ", pluginCheckResult);
+                await this.refundSwap(swap);
+                unlock();
+                return;
+            }
+            if (swap.state !== FromBtcTrustedSwap_1.FromBtcTrustedSwapState.BTC_CONFIRMED) {
+                unlock();
+                return;
+            }
             await chainInterface.sendAndConfirm(signer, txns, true, null, false, async (txId, rawTx) => {
                 swap.txIds = { init: txId };
                 swap.scRawTx = rawTx;

--- a/dist/swaps/trusted/frombtc_trusted/FromBtcTrustedSwap.d.ts
+++ b/dist/swaps/trusted/frombtc_trusted/FromBtcTrustedSwap.d.ts
@@ -49,4 +49,5 @@ export declare class FromBtcTrustedSwap extends SwapHandlerSwap<FromBtcTrustedSw
     isInitiated(): boolean;
     isSuccess(): boolean;
     getIdentifierHash(): string;
+    getDestinationAddress(): string;
 }

--- a/dist/swaps/trusted/frombtc_trusted/FromBtcTrustedSwap.js
+++ b/dist/swaps/trusted/frombtc_trusted/FromBtcTrustedSwap.js
@@ -114,5 +114,8 @@ class FromBtcTrustedSwap extends SwapHandlerSwap_1.SwapHandlerSwap {
     getIdentifierHash() {
         return (0, crypto_1.createHash)("sha256").update(this.btcAddress).digest().toString("hex");
     }
+    getDestinationAddress() {
+        return this.dstAddress;
+    }
 }
 exports.FromBtcTrustedSwap = FromBtcTrustedSwap;

--- a/dist/swaps/trusted/frombtcln_trusted/FromBtcLnTrusted.js
+++ b/dist/swaps/trusted/frombtcln_trusted/FromBtcLnTrusted.js
@@ -9,6 +9,7 @@ const SchemaVerifier_1 = require("../../../utils/paramcoders/SchemaVerifier");
 const PluginManager_1 = require("../../../plugins/PluginManager");
 const FromBtcAmountAssertions_1 = require("../../assertions/FromBtcAmountAssertions");
 const LightningAssertions_1 = require("../../assertions/LightningAssertions");
+const IPlugin_1 = require("../../../plugins/IPlugin");
 /**
  * Swap handler handling from BTCLN swaps using submarine swaps
  */
@@ -183,6 +184,19 @@ class FromBtcLnTrusted extends SwapHandler_1.SwapHandler {
             let unlock = invoiceData.lock(Infinity);
             if (unlock == null)
                 return;
+            const pluginCheckResult = await PluginManager_1.PluginManager.onHandlePreFromBtcExecute(SwapHandler_1.SwapHandlerType.FROM_BTCLN_TRUSTED, invoiceData);
+            if ((0, IPlugin_1.isQuoteThrow)(pluginCheckResult)) {
+                await this.cancelSwapAndInvoice(invoiceData);
+                unlock();
+                throw {
+                    code: 29999,
+                    msg: pluginCheckResult.message
+                };
+            }
+            if (invoiceData.state !== FromBtcLnTrustedSwap_1.FromBtcLnTrustedSwapState.RECEIVED) {
+                unlock();
+                return;
+            }
             const result = await chainInterface.sendAndConfirm(signer, txns, true, null, false, async (txId, rawTx) => {
                 invoiceData.txIds = { init: txId };
                 invoiceData.scRawTx = rawTx;

--- a/dist/swaps/trusted/frombtcln_trusted/FromBtcLnTrustedSwap.d.ts
+++ b/dist/swaps/trusted/frombtcln_trusted/FromBtcLnTrustedSwap.d.ts
@@ -31,4 +31,5 @@ export declare class FromBtcLnTrustedSwap extends SwapHandlerSwap<FromBtcLnTrust
     isInitiated(): boolean;
     isSuccess(): boolean;
     getIdentifierHash(): string;
+    getDestinationAddress(): string;
 }

--- a/dist/swaps/trusted/frombtcln_trusted/FromBtcLnTrustedSwap.js
+++ b/dist/swaps/trusted/frombtcln_trusted/FromBtcLnTrustedSwap.js
@@ -77,5 +77,8 @@ class FromBtcLnTrustedSwap extends SwapHandlerSwap_1.SwapHandlerSwap {
     getIdentifierHash() {
         return (0, crypto_1.createHash)("sha256").update(Buffer.from(this.secret, "hex")).digest().toString("hex");
     }
+    getDestinationAddress() {
+        return this.dstAddress;
+    }
 }
 exports.FromBtcLnTrustedSwap = FromBtcLnTrustedSwap;

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "author": "adambor",
   "license": "ISC",
   "dependencies": {
-    "@atomiqlabs/base": "github:atomiqlabs/atomiq-base#develop",
+    "@atomiqlabs/base": "^13.5.0",
     "@atomiqlabs/server-base": "^3.0.0",
     "@scure/btc-signer": "1.6.0",
     "express": "4.21.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atomiqlabs/lp-lib",
-  "version": "17.2.0",
+  "version": "17.2.1",
   "description": "Main functionality implementation for atomiq LP node",
   "main": "./dist/index.js",
   "types:": "./dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atomiqlabs/lp-lib",
-  "version": "17.2.2",
+  "version": "17.3.0",
   "description": "Main functionality implementation for atomiq LP node",
   "main": "./dist/index.js",
   "types:": "./dist/index.d.ts",
@@ -23,7 +23,7 @@
   "author": "adambor",
   "license": "ISC",
   "dependencies": {
-    "@atomiqlabs/base": "^13.0.4",
+    "@atomiqlabs/base": "github:atomiqlabs/atomiq-base#develop",
     "@atomiqlabs/server-base": "^3.0.0",
     "@scure/btc-signer": "1.6.0",
     "express": "4.21.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atomiqlabs/lp-lib",
-  "version": "17.1.2",
+  "version": "17.2.0",
   "description": "Main functionality implementation for atomiq LP node",
   "main": "./dist/index.js",
   "types:": "./dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@atomiqlabs/lp-lib",
-  "version": "17.2.1",
+  "version": "17.2.2",
   "description": "Main functionality implementation for atomiq LP node",
   "main": "./dist/index.js",
   "types:": "./dist/index.d.ts",

--- a/src/info/InfoHandler.ts
+++ b/src/info/InfoHandler.ts
@@ -16,7 +16,8 @@ type InfoHandlerResponse = {
     chains: {
         [chainIdentifier: string]: {
             address: string,
-            signature: string
+            signature: string,
+            contractVersion: string
         }
     }
 }
@@ -74,14 +75,16 @@ export class InfoHandler {
             const chains: {
                 [chainIdentifier: string]: {
                     address: string,
-                    signature: string
+                    signature: string,
+                    contractVersion: string
                 }
             } = {};
             for(let chainIdentifier in this.chainData.chains) {
                 const singleChain = this.chainData.chains[chainIdentifier];
                 chains[chainIdentifier] = {
                     address: singleChain.signer.getAddress(),
-                    signature: await singleChain.swapContract.getDataSignature(singleChain.signer, envelopeBuffer)
+                    signature: await singleChain.swapContract.getDataSignature(singleChain.signer, envelopeBuffer),
+                    contractVersion: singleChain.contractVersion ?? "v1"
                 };
             }
 

--- a/src/plugins/IPlugin.ts
+++ b/src/plugins/IPlugin.ts
@@ -47,7 +47,7 @@ export type QuoteAmountTooLow = {
 }
 
 export function isQuoteAmountTooLow(obj: any): obj is QuoteAmountTooLow {
-    return obj!=null && obj.type==="low" && typeof(obj.data)==="object" && typeof(obj.data.min)==="bigint" && typeof(obj.data.max)==="bigint";
+    return obj!=null && obj.type==="low" && obj.data!=null && typeof(obj.data)==="object" && typeof(obj.data.min)==="bigint" && typeof(obj.data.max)==="bigint";
 }
 
 export type QuoteAmountTooHigh = {
@@ -56,7 +56,7 @@ export type QuoteAmountTooHigh = {
 }
 
 export function isQuoteAmountTooHigh(obj: any): obj is QuoteAmountTooHigh {
-    return obj!=null && obj.type==="high" && typeof(obj.data)==="object" && typeof(obj.data.min)==="bigint" && typeof(obj.data.max)==="bigint";
+    return obj!=null && obj.type==="high" && obj.data!=null && typeof(obj.data)==="object" && typeof(obj.data.min)==="bigint" && typeof(obj.data.max)==="bigint";
 }
 
 export type PluginQuote = {
@@ -67,8 +67,8 @@ export type PluginQuote = {
 
 export function isPluginQuote(obj: any): obj is PluginQuote {
     return obj!=null && obj.type==="success" &&
-        typeof(obj.amount)==="object" && typeof(obj.amount.input)==="boolean" && typeof(obj.amount.amount)==="bigint" &&
-        typeof(obj.swapFee)==="object" && typeof(obj.swapFee.inInputTokens)==="bigint" && typeof(obj.swapFee.inOutputTokens)==="bigint";
+        obj.amount!=null && typeof(obj.amount)==="object" && typeof(obj.amount.input)==="boolean" && typeof(obj.amount.amount)==="bigint" &&
+        obj.swapFee!=null && typeof(obj.swapFee)==="object" && typeof(obj.swapFee.inInputTokens)==="bigint" && typeof(obj.swapFee.inOutputTokens)==="bigint";
 }
 
 export type ToBtcPluginQuote = PluginQuote & {
@@ -76,7 +76,7 @@ export type ToBtcPluginQuote = PluginQuote & {
 }
 
 export function isToBtcPluginQuote(obj: any): obj is ToBtcPluginQuote {
-    return obj!=null && typeof(obj.networkFee)==="object" && typeof(obj.networkFee.inInputTokens)==="bigint" && typeof(obj.networkFee.inOutputTokens)==="bigint" &&
+    return obj!=null && obj.networkFee!=null && typeof(obj.networkFee)==="object" && typeof(obj.networkFee.inInputTokens)==="bigint" && typeof(obj.networkFee.inOutputTokens)==="bigint" &&
         isPluginQuote(obj);
 }
 

--- a/src/plugins/IPlugin.ts
+++ b/src/plugins/IPlugin.ts
@@ -21,7 +21,7 @@ export type QuoteThrow = {
 }
 
 export function isQuoteThrow(obj: any): obj is QuoteThrow {
-    return obj.type==="throw" && typeof(obj.message)==="string";
+    return obj!=null && obj.type==="throw" && typeof(obj.message)==="string";
 }
 
 export type QuoteSetFees = {
@@ -33,7 +33,8 @@ export type QuoteSetFees = {
 };
 
 export function isQuoteSetFees(obj: any): obj is QuoteSetFees {
-    return obj.type==="fees" &&
+    return obj!=null &&
+        obj.type==="fees" &&
         (obj.baseFee==null || typeof(obj.baseFee) === "bigint") &&
         (obj.feePPM==null || typeof(obj.feePPM) === "bigint") &&
         (obj.securityDepositApyPPM==null || typeof(obj.securityDepositApyPPM) === "bigint") &&
@@ -46,7 +47,7 @@ export type QuoteAmountTooLow = {
 }
 
 export function isQuoteAmountTooLow(obj: any): obj is QuoteAmountTooLow {
-    return obj.type==="low" && typeof(obj.data)==="object" && typeof(obj.data.min)==="bigint" && typeof(obj.data.max)==="bigint";
+    return obj!=null && obj.type==="low" && typeof(obj.data)==="object" && typeof(obj.data.min)==="bigint" && typeof(obj.data.max)==="bigint";
 }
 
 export type QuoteAmountTooHigh = {
@@ -55,7 +56,7 @@ export type QuoteAmountTooHigh = {
 }
 
 export function isQuoteAmountTooHigh(obj: any): obj is QuoteAmountTooHigh {
-    return obj.type==="high" && typeof(obj.data)==="object" && typeof(obj.data.min)==="bigint" && typeof(obj.data.max)==="bigint";
+    return obj!=null && obj.type==="high" && typeof(obj.data)==="object" && typeof(obj.data.min)==="bigint" && typeof(obj.data.max)==="bigint";
 }
 
 export type PluginQuote = {
@@ -65,7 +66,7 @@ export type PluginQuote = {
 };
 
 export function isPluginQuote(obj: any): obj is PluginQuote {
-    return obj.type==="success" &&
+    return obj!=null && obj.type==="success" &&
         typeof(obj.amount)==="object" && typeof(obj.amount.input)==="boolean" && typeof(obj.amount.amount)==="bigint" &&
         typeof(obj.swapFee)==="object" && typeof(obj.swapFee.inInputTokens)==="bigint" && typeof(obj.swapFee.inOutputTokens)==="bigint";
 }
@@ -75,7 +76,7 @@ export type ToBtcPluginQuote = PluginQuote & {
 }
 
 export function isToBtcPluginQuote(obj: any): obj is ToBtcPluginQuote {
-    return typeof(obj.networkFee)==="object" && typeof(obj.networkFee.inInputTokens)==="bigint" && typeof(obj.networkFee.inOutputTokens)==="bigint" &&
+    return obj!=null && typeof(obj.networkFee)==="object" && typeof(obj.networkFee.inInputTokens)==="bigint" && typeof(obj.networkFee.inOutputTokens)==="bigint" &&
         isPluginQuote(obj);
 }
 

--- a/src/plugins/IPlugin.ts
+++ b/src/plugins/IPlugin.ts
@@ -1,11 +1,12 @@
 import {BitcoinRpc} from "@atomiqlabs/base";
 import {
-    FromBtcLnRequestType,
-    FromBtcRequestType, FromBtcTrustedRequestType,
+    FromBtcLnAbs, FromBtcLnAutoSwap,
+    FromBtcLnRequestType, FromBtcLnSwapAbs, FromBtcLnTrustedSwap,
+    FromBtcRequestType, FromBtcSwapAbs, FromBtcTrustedRequestType, FromBtcTrustedSwap,
     ISwapPrice, MultichainData, RequestData, SpvVaultPostQuote, SpvVaultSwap, SpvVaultSwapRequestType,
     SwapHandler, SwapHandlerType,
-    ToBtcLnRequestType,
-    ToBtcRequestType
+    ToBtcLnRequestType, ToBtcLnSwapAbs,
+    ToBtcRequestType, ToBtcSwapAbs
 } from "..";
 import {SwapHandlerSwap} from "../swaps/SwapHandlerSwap";
 import {Command} from "@atomiqlabs/server-base";
@@ -133,6 +134,22 @@ export interface IPlugin {
         fees: {baseFeeInBtc: bigint, feePPM: bigint},
         gasTokenAmount?: {input: false, amount: bigint, token: string, pricePrefetch?: Promise<bigint>}
     ): Promise<QuoteThrow | QuoteSetFees | QuoteAmountTooLow | QuoteAmountTooHigh | PluginQuote>;
+    /**
+     * Triggered when the quote is about to get executed, this means:
+     * - FROM_BTCLN - lightning network payment received and the LP is about to sign an authorization allowing the user to settle
+     * - FROM_BTC - triggered on quote request, before the final authorization is given to the user
+     * - FROM_BTCLN_TRUSTED - triggered when the LP receives the funds on the source chain and before destination funds are sent
+     * - FROM_BTC_TRUSTED - triggered when the LP receives the funds on the source chain and before destination funds are sent
+     * - FROM_BTC_SPV - triggered before LP broadcasts the co-signed swap PSBT
+     * - FROM_BTCLN_AUTO - lightning network payment received and the LP is about to offer an HTLC to the user
+     *
+     * @param swapType
+     * @param swap
+     */
+    onHandlePreFromBtcExecute?(
+        swapType: SwapHandlerType.FROM_BTCLN | SwapHandlerType.FROM_BTC | SwapHandlerType.FROM_BTCLN_TRUSTED | SwapHandlerType.FROM_BTC_TRUSTED | SwapHandlerType.FROM_BTC_SPV | SwapHandlerType.FROM_BTCLN_AUTO,
+        swap: FromBtcLnSwapAbs | FromBtcSwapAbs | FromBtcLnTrustedSwap | FromBtcTrustedSwap | SpvVaultSwap | FromBtcLnAutoSwap
+    ): Promise<QuoteThrow | null>;
 
     onHandlePreToBtcQuote?(
         swapType: SwapHandlerType.TO_BTCLN | SwapHandlerType.TO_BTC,
@@ -150,6 +167,10 @@ export interface IPlugin {
         constraints: {minInBtc: bigint, maxInBtc: bigint},
         fees: {baseFeeInBtc: bigint, feePPM: bigint, networkFeeGetter: (amount: bigint) => Promise<bigint>}
     ): Promise<QuoteThrow | QuoteSetFees | QuoteAmountTooLow | QuoteAmountTooHigh | ToBtcPluginQuote>;
+    onHandlePreToBtcExecute?(
+        swapType: SwapHandlerType.TO_BTCLN | SwapHandlerType.TO_BTC,
+        swap: ToBtcLnSwapAbs | ToBtcSwapAbs
+    ): Promise<QuoteThrow | null>;
 
     onHandlePostedFromBtcQuote?(
         swapType: SwapHandlerType.FROM_BTC_SPV,

--- a/src/plugins/PluginManager.ts
+++ b/src/plugins/PluginManager.ts
@@ -8,12 +8,13 @@ import {
     QuoteThrow, ToBtcPluginQuote
 } from "./IPlugin";
 import {
-    FromBtcLnRequestType,
-    FromBtcRequestType, FromBtcTrustedRequestType,
+    FromBtcLnAutoSwap,
+    FromBtcLnRequestType, FromBtcLnSwapAbs, FromBtcLnTrustedSwap,
+    FromBtcRequestType, FromBtcSwapAbs, FromBtcTrustedRequestType, FromBtcTrustedSwap,
     ISwapPrice, MultichainData, RequestData, SpvVaultPostQuote, SpvVaultSwap, SpvVaultSwapRequestType,
     SwapHandler, SwapHandlerType,
-    ToBtcLnRequestType,
-    ToBtcRequestType
+    ToBtcLnRequestType, ToBtcLnSwapAbs,
+    ToBtcRequestType, ToBtcSwapAbs
 } from "..";
 import {SwapHandlerSwap} from "../swaps/SwapHandlerSwap";
 import * as fs from "fs";
@@ -224,6 +225,23 @@ export class PluginManager {
         return null;
     }
 
+    static async onHandlePreFromBtcExecute(
+        swapType: SwapHandlerType.FROM_BTCLN | SwapHandlerType.FROM_BTC | SwapHandlerType.FROM_BTCLN_TRUSTED | SwapHandlerType.FROM_BTC_TRUSTED | SwapHandlerType.FROM_BTC_SPV | SwapHandlerType.FROM_BTCLN_AUTO,
+        swap: FromBtcLnSwapAbs | FromBtcSwapAbs | FromBtcLnTrustedSwap | FromBtcTrustedSwap | SpvVaultSwap | FromBtcLnAutoSwap
+    ): Promise<QuoteThrow | null> {
+        for(let plugin of PluginManager.plugins.values()) {
+            try {
+                if(plugin.onHandlePreFromBtcExecute!=null) {
+                    const result = await plugin.onHandlePreFromBtcExecute(swapType, swap);
+                    if(result!=null && isQuoteThrow(result)) return result;
+                }
+            } catch (e) {
+                pluginLogger.error(plugin, "onHandlePreFromBtcExecute(): plugin error", e);
+            }
+        }
+        return null;
+    }
+
     static async onHandlePostToBtcQuote<T extends {networkFee: bigint}>(
         swapType: SwapHandlerType.TO_BTCLN | SwapHandlerType.TO_BTC,
         request: RequestData<ToBtcLnRequestType | ToBtcRequestType>,
@@ -286,6 +304,23 @@ export class PluginManager {
                 }
             } catch (e) {
                 pluginLogger.error(plugin, "onSwapRequestToBtcLn(): plugin error", e);
+            }
+        }
+        return null;
+    }
+
+    static async onHandlePreToBtcExecute(
+        swapType: SwapHandlerType.TO_BTCLN | SwapHandlerType.TO_BTC,
+        swap: ToBtcLnSwapAbs | ToBtcSwapAbs
+    ): Promise<QuoteThrow | null> {
+        for(let plugin of PluginManager.plugins.values()) {
+            try {
+                if(plugin.onHandlePreToBtcExecute!=null) {
+                    const result = await plugin.onHandlePreToBtcExecute(swapType, swap);
+                    if(result!=null && isQuoteThrow(result)) return result;
+                }
+            } catch (e) {
+                pluginLogger.error(plugin, "onHandlePreToBtcExecute(): plugin error", e);
             }
         }
         return null;

--- a/src/swaps/SwapHandler.ts
+++ b/src/swaps/SwapHandler.ts
@@ -62,7 +62,8 @@ export type ChainData<T extends ChainType = ChainType> = {
     allowedTokens: string[],
     tokenMultipliers?: {[tokenAddress: string]: bigint},
     allowedDepositTokens?: string[],
-    btcRelay?: T["BtcRelay"]
+    btcRelay?: T["BtcRelay"],
+    contractVersion?: string
 }
 
 export type RequestData<T> = {

--- a/src/swaps/SwapHandlerSwap.ts
+++ b/src/swaps/SwapHandlerSwap.ts
@@ -139,4 +139,6 @@ export abstract class SwapHandlerSwap<S = any> extends Lockable implements Stora
      */
     abstract getSwapFee(): {inInputToken: bigint, inOutputToken: bigint};
 
+    abstract getDestinationAddress(): string;
+
 }

--- a/src/swaps/escrow/frombtc_abstract/FromBtcAbs.ts
+++ b/src/swaps/escrow/frombtc_abstract/FromBtcAbs.ts
@@ -20,6 +20,8 @@ import {IParamReader} from "../../../utils/paramcoders/IParamReader";
 import {ServerParamEncoder} from "../../../utils/paramcoders/server/ServerParamEncoder";
 import {FromBtcBaseConfig, FromBtcBaseSwapHandler} from "../FromBtcBaseSwapHandler";
 import {IBitcoinWallet} from "../../../wallets/IBitcoinWallet";
+import {isQuoteThrow} from "../../../plugins/IPlugin";
+import {FromBtcLnSwapState} from "../frombtcln_abstract/FromBtcLnSwapAbs";
 
 export type FromBtcConfig = FromBtcBaseConfig & {
     confirmations: number,
@@ -408,6 +410,15 @@ export class FromBtcAbs extends FromBtcBaseSwapHandler<FromBtcSwapAbs, FromBtcSw
             createdSwap.timeout = sigData.timeout;
             createdSwap.signature = sigData.signature;
             createdSwap.feeRate = sigData.feeRate;
+
+            const pluginCheckResult = await PluginManager.onHandlePreFromBtcExecute(
+                SwapHandlerType.FROM_BTC,
+                createdSwap
+            );
+            if(isQuoteThrow(pluginCheckResult)) throw {
+                code: 29999,
+                msg: pluginCheckResult.message
+            };
 
             await PluginManager.swapCreate(createdSwap);
             await this.saveSwapData(createdSwap);

--- a/src/swaps/escrow/frombtc_abstract/FromBtcSwapAbs.ts
+++ b/src/swaps/escrow/frombtc_abstract/FromBtcSwapAbs.ts
@@ -58,4 +58,8 @@ export class FromBtcSwapAbs<T extends SwapData = SwapData> extends FromBtcBaseSw
         return this.amount;
     }
 
+    getDestinationAddress(): string {
+        return this.data.getClaimer();
+    }
+
 }

--- a/src/swaps/escrow/frombtcln_abstract/FromBtcLnAbs.ts
+++ b/src/swaps/escrow/frombtcln_abstract/FromBtcLnAbs.ts
@@ -27,6 +27,8 @@ import {
     LightningNetworkInvoice
 } from "../../../wallets/ILightningWallet";
 import {LightningAssertions} from "../../assertions/LightningAssertions";
+import {isQuoteThrow} from "../../../plugins/IPlugin";
+import {FromBtcLnAutoSwapState} from "../frombtcln_autoinit/FromBtcLnAutoSwap";
 
 export type FromBtcLnConfig = FromBtcBaseConfig & {
     invoiceTimeoutSeconds?: number,
@@ -373,6 +375,20 @@ export class FromBtcLnAbs extends FromBtcBaseSwapHandler<FromBtcLnSwapAbs, FromB
         );
         //No need to check abortController anymore since all pending promises are resolved by now
         if(invoiceData.metadata!=null) invoiceData.metadata.times.htlcSwapSigned = Date.now();
+
+        const pluginCheckResult = await PluginManager.onHandlePreFromBtcExecute(
+            SwapHandlerType.FROM_BTCLN,
+            invoiceData
+        );
+        if(isQuoteThrow(pluginCheckResult)) {
+            const error = {
+                code: 29999,
+                msg: pluginCheckResult.message
+            };
+            if(invoiceData.metadata!=null) invoiceData.metadata.htlcReceiveError = error;
+            if(invoiceData.state===FromBtcLnSwapState.CREATED) await this.cancelSwapAndInvoice(invoiceData);
+            throw error;
+        }
 
         //Important to prevent race condition and issuing 2 signed init messages at the same time
         if(invoiceData.state===FromBtcLnSwapState.CREATED) {
@@ -836,7 +852,13 @@ export class FromBtcLnAbs extends FromBtcBaseSwapHandler<FromBtcLnSwapAbs, FromB
                 msg: "Invoice already committed"
             };
 
-            res.status(200).json({
+            if (swap.state === FromBtcLnSwapState.CLAIMED) throw {
+                _httpStatus: 200,
+                code: 10005,
+                msg: "Invoice already committed & claimed"
+            };
+
+            if (swap.state === FromBtcLnSwapState.RECEIVED) res.status(200).json({
                 code: 10000,
                 msg: "Success",
                 data: {

--- a/src/swaps/escrow/frombtcln_abstract/FromBtcLnSwapAbs.ts
+++ b/src/swaps/escrow/frombtcln_abstract/FromBtcLnSwapAbs.ts
@@ -138,4 +138,8 @@ export class FromBtcLnSwapAbs<T extends SwapData = SwapData> extends FromBtcBase
         return this.state===FromBtcLnSwapState.SETTLED;
     }
 
+    getDestinationAddress(): string {
+        return this.claimer
+    }
+
 }

--- a/src/swaps/escrow/frombtcln_autoinit/FromBtcLnAuto.ts
+++ b/src/swaps/escrow/frombtcln_autoinit/FromBtcLnAuto.ts
@@ -836,7 +836,6 @@ export class FromBtcLnAuto extends FromBtcBaseSwapHandler<FromBtcLnAutoSwap, Fro
             };
 
             if (
-                swap.state === FromBtcLnAutoSwapState.RECEIVED ||
                 swap.state === FromBtcLnAutoSwapState.TXS_SENT ||
                 swap.state === FromBtcLnAutoSwapState.COMMITED
             ) {

--- a/src/swaps/escrow/frombtcln_autoinit/FromBtcLnAuto.ts
+++ b/src/swaps/escrow/frombtcln_autoinit/FromBtcLnAuto.ts
@@ -19,6 +19,7 @@ import {
     LightningNetworkInvoice
 } from "../../../wallets/ILightningWallet";
 import {LightningAssertions} from "../../assertions/LightningAssertions";
+import {isQuoteThrow} from "../../../plugins/IPlugin";
 
 export type FromBtcLnAutoConfig = FromBtcBaseConfig & {
     invoiceTimeoutSeconds?: number,
@@ -419,6 +420,20 @@ export class FromBtcLnAuto extends FromBtcBaseSwapHandler<FromBtcLnAutoSwap, Fro
             timeout: invoiceData.timeout,
             signature: invoiceData.signature
         }, true);
+
+        const pluginCheckResult = await PluginManager.onHandlePreFromBtcExecute(
+            SwapHandlerType.FROM_BTCLN_AUTO,
+            invoiceData
+        );
+        if(isQuoteThrow(pluginCheckResult)) {
+            const error = {
+                code: 29999,
+                msg: pluginCheckResult.message
+            };
+            if(invoiceData.metadata!=null) invoiceData.metadata.htlcOfferError = error;
+            if(invoiceData.state===FromBtcLnAutoSwapState.RECEIVED) await this.cancelSwapAndInvoice(invoiceData);
+            throw error;
+        }
 
         if(invoiceData.state===FromBtcLnAutoSwapState.RECEIVED) {
             //Re-check the current HTLC count

--- a/src/swaps/escrow/frombtcln_autoinit/FromBtcLnAutoSwap.ts
+++ b/src/swaps/escrow/frombtcln_autoinit/FromBtcLnAutoSwap.ts
@@ -193,4 +193,8 @@ export class FromBtcLnAutoSwap<T extends SwapData = SwapData> extends FromBtcBas
         return this.state===FromBtcLnAutoSwapState.SETTLED;
     }
 
+    getDestinationAddress(): string {
+        return this.claimer
+    }
+
 }

--- a/src/swaps/escrow/tobtc_abstract/ToBtcAbs.ts
+++ b/src/swaps/escrow/tobtc_abstract/ToBtcAbs.ts
@@ -23,6 +23,8 @@ import {ServerParamEncoder} from "../../../utils/paramcoders/server/ServerParamE
 import {ToBtcBaseConfig, ToBtcBaseSwapHandler} from "../ToBtcBaseSwapHandler";
 import {IBitcoinWallet} from "../../../wallets/IBitcoinWallet";
 import {checkTransactionReplaced} from "../../../utils/BitcoinUtils";
+import {isQuoteThrow} from "../../../plugins/IPlugin";
+import {FromBtcLnAutoSwapState} from "../frombtcln_autoinit/FromBtcLnAutoSwap";
 
 const OUTPUT_SCRIPT_MAX_LENGTH = 200;
 
@@ -435,8 +437,32 @@ export class ToBtcAbs extends ToBtcBaseSwapHandler<ToBtcSwapAbs, ToBtcSwapState>
         }
 
         if(swap.state===ToBtcSwapState.COMMITED) {
-            const unlock: () => boolean = swap.lock(60);
+            const unlock: () => boolean = swap.lock(Infinity);
             if(unlock==null) return;
+
+            const pluginCheckResult = await PluginManager.onHandlePreToBtcExecute(
+                SwapHandlerType.TO_BTC,
+                swap
+            );
+            if(isQuoteThrow(pluginCheckResult)) {
+                const error = {
+                    code: 29999,
+                    msg: pluginCheckResult.message
+                };
+                this.swapLogger.error(swap, "processInitialized(state=COMMITED): setting state to NON_PAYABLE due to send bitcoin payment error", error);
+                if(swap.metadata!=null) swap.metadata.payError = error;
+                unlock();
+                if(swap.state===ToBtcSwapState.COMMITED) {
+                    await swap.setState(ToBtcSwapState.NON_PAYABLE);
+                    await this.saveSwapData(swap);
+                }
+                return;
+            }
+
+            if(swap.state!==ToBtcSwapState.COMMITED) {
+                unlock();
+                return;
+            }
 
             this.swapLogger.debug(swap, "processInitialized(state=COMMITED): sending bitcoin transaction, address: "+swap.address);
 
@@ -453,9 +479,9 @@ export class ToBtcAbs extends ToBtcBaseSwapHandler<ToBtcSwapAbs, ToBtcSwapState>
                     this.swapLogger.error(swap, "processInitialized(state=COMMITED): send bitcoin payment error", e);
                     throw e;
                 }
+            } finally {
+                unlock();
             }
-
-            unlock();
         }
 
         if(swap.state===ToBtcSwapState.NON_PAYABLE) return;

--- a/src/swaps/escrow/tobtc_abstract/ToBtcSwapAbs.ts
+++ b/src/swaps/escrow/tobtc_abstract/ToBtcSwapAbs.ts
@@ -105,4 +105,8 @@ export class ToBtcSwapAbs<T extends SwapData = SwapData> extends ToBtcBaseSwap<T
         return this.state===ToBtcSwapState.CLAIMED;
     }
 
+    getDestinationAddress(): string {
+        return this.address;
+    }
+
 }

--- a/src/swaps/escrow/tobtcln_abstract/ToBtcLnAbs.ts
+++ b/src/swaps/escrow/tobtcln_abstract/ToBtcLnAbs.ts
@@ -28,6 +28,8 @@ import {
     routesMatch
 } from "../../../wallets/ILightningWallet";
 import { LightningAssertions } from "../../assertions/LightningAssertions";
+import {isQuoteThrow} from "../../../plugins/IPlugin";
+import {ToBtcSwapState} from "../tobtc_abstract/ToBtcSwapAbs";
 
 export type ToBtcLnConfig = ToBtcBaseConfig & {
     routingFeeMultiplier: bigint,
@@ -305,7 +307,7 @@ export class ToBtcLnAbs extends ToBtcBaseSwapHandler<ToBtcLnSwapAbs, ToBtcLnSwap
         return true;
     }
 
-    private async sendLightningPayment(swap: ToBtcLnSwapAbs): Promise<void> {
+    private async sendLightningPayment(swap: ToBtcLnSwapAbs): Promise<boolean> {
         const decodedPR = await this.lightning.parsePaymentRequest(swap.pr);
         const expiryTimestamp: bigint = swap.data.getExpiry();
         const currentTimestamp: bigint = BigInt(Math.floor(Date.now()/1000));
@@ -336,6 +338,19 @@ export class ToBtcLnAbs extends ToBtcBaseSwapHandler<ToBtcLnSwapAbs, ToBtcLnSwap
 
         const blockHeight = await this.lightning.getBlockheight();
 
+        const pluginCheckResult = await PluginManager.onHandlePreToBtcExecute(
+            SwapHandlerType.TO_BTCLN,
+            swap
+        );
+        if(isQuoteThrow(pluginCheckResult)) {
+            throw {
+                code: 29999,
+                msg: pluginCheckResult.message
+            };
+        }
+
+        if(swap.state!==ToBtcLnSwapState.COMMITED) return false;
+
         swap.payInitiated = true;
         await this.saveSwapData(swap);
         try {
@@ -354,6 +369,8 @@ export class ToBtcLnAbs extends ToBtcBaseSwapHandler<ToBtcLnSwapAbs, ToBtcLnSwap
             }
         }
         if(swap.metadata!=null) swap.metadata.times.payComplete = Date.now();
+
+        return true;
     }
 
     /**
@@ -404,7 +421,7 @@ export class ToBtcLnAbs extends ToBtcBaseSwapHandler<ToBtcLnSwapAbs, ToBtcLnSwap
             await swap.setState(ToBtcLnSwapState.COMMITED);
             await this.saveSwapData(swap);
             try {
-                await this.sendLightningPayment(swap);
+                if(!await this.sendLightningPayment(swap)) return;
             } catch (e) {
                 this.swapLogger.error(swap, "processInitialized(): lightning payment error", e);
                 if(isDefinedRuntimeError(e)) {

--- a/src/swaps/escrow/tobtcln_abstract/ToBtcLnSwapAbs.ts
+++ b/src/swaps/escrow/tobtcln_abstract/ToBtcLnSwapAbs.ts
@@ -78,4 +78,8 @@ export class ToBtcLnSwapAbs<T extends SwapData = SwapData> extends ToBtcBaseSwap
         return this.state===ToBtcLnSwapState.CLAIMED;
     }
 
+    getDestinationAddress(): string {
+        return this.pr;
+    }
+
 }

--- a/src/swaps/spv_vault_swap/SpvVaultSwap.ts
+++ b/src/swaps/spv_vault_swap/SpvVaultSwap.ts
@@ -225,4 +225,8 @@ export class SpvVaultSwap extends SwapHandlerSwap<SpvVaultSwapState> {
         return this.state===SpvVaultSwapState.CLAIMED;
     }
 
+    getDestinationAddress(): string {
+        return this.recipient;
+    }
+
 }

--- a/src/swaps/spv_vault_swap/SpvVaultSwapHandler.ts
+++ b/src/swaps/spv_vault_swap/SpvVaultSwapHandler.ts
@@ -37,6 +37,7 @@ import {Transaction} from "@scure/btc-signer";
 import {SpvVaults, VAULT_DUST_AMOUNT} from "./SpvVaults";
 import {isLegacyInput} from "../../utils/BitcoinUtils";
 import {AmountAssertions} from "../assertions/AmountAssertions";
+import {isQuoteThrow} from "../../plugins/IPlugin";
 
 export type SpvVaultSwapHandlerConfig = SwapBaseConfig & {
     vaultsCheckInterval: number,
@@ -599,7 +600,7 @@ export class SpvVaultSwapHandler extends SwapHandler<SpvVaultSwap, SpvVaultSwapS
             if(swap.vaultUtxo!==vault.getLatestUtxo()) {
                 throw {
                     code: 20510,
-                    msg: "Vault UTXO already spent, please try again!"
+                    msg: "Vault UTXO already spent, please get another quote and try again!"
                 };
             }
 
@@ -624,11 +625,25 @@ export class SpvVaultSwapHandler extends SwapHandler<SpvVaultSwap, SpvVaultSwapS
                 msg: "Bitcoin transaction size too large, maximum: "+TX_MAX_VSIZE+" actual: "+txVsize
             };
 
+            const pluginCheckResult = await PluginManager.onHandlePreFromBtcExecute(
+                SwapHandlerType.FROM_BTC_SPV,
+                swap
+            );
+            if(isQuoteThrow(pluginCheckResult)) {
+                const error = {
+                    code: 29999,
+                    msg: pluginCheckResult.message
+                }
+                if(swap.metadata!=null) swap.metadata.postQuoteError = error;
+                await this.removeSwapData(swap, SpvVaultSwapState.FAILED);
+                throw error;
+            }
+
             await this.Vaults.checkVaultReplacedTransactions(vault, true);
             if(swap.vaultUtxo!==vault.getLatestUtxo()) {
                 throw {
                     code: 20510,
-                    msg: "Vault UTXO already spent, please try again!"
+                    msg: "Vault UTXO already spent, please get another quote and try again!"
                 };
             }
 

--- a/src/swaps/trusted/frombtc_trusted/FromBtcTrusted.ts
+++ b/src/swaps/trusted/frombtc_trusted/FromBtcTrusted.ts
@@ -11,6 +11,7 @@ import {ServerParamEncoder} from "../../../utils/paramcoders/server/ServerParamE
 import {FieldTypeEnum, verifySchema} from "../../../utils/paramcoders/SchemaVerifier";
 import {IBitcoinWallet} from "../../../wallets/IBitcoinWallet";
 import {FromBtcAmountAssertions} from "../../assertions/FromBtcAmountAssertions";
+import {isQuoteThrow} from "../../../plugins/IPlugin";
 
 export type FromBtcTrustedConfig = SwapBaseConfig & {
     doubleSpendCheckInterval: number,
@@ -67,49 +68,51 @@ export class FromBtcTrusted extends SwapHandler<FromBtcTrustedSwap, FromBtcTrust
     }
 
     private async refundSwap(swap: FromBtcTrustedSwap) {
-        if(swap.refundAddress==null) {
-            if(swap.state!==FromBtcTrustedSwapState.REFUNDABLE) {
-                await swap.setState(FromBtcTrustedSwapState.REFUNDABLE);
-                await this.storageManager.saveData(swap.getIdentifierHash(), swap.getSequence(), swap);
-            }
-            return;
+        if(swap.state!==FromBtcTrustedSwapState.REFUNDABLE) {
+            await swap.setState(FromBtcTrustedSwapState.REFUNDABLE);
+            await this.storageManager.saveData(swap.getIdentifierHash(), swap.getSequence(), swap);
         }
 
-        let unlock = swap.lock(30*1000);
+        if(swap.refundAddress==null) return;
+
+        let unlock = swap.lock(Infinity);
         if(unlock==null) return;
 
-        const feeRate = await this.bitcoin.getFeeRate();
+        try {
+            const feeRate = await this.bitcoin.getFeeRate();
 
-        const ourOutput = swap.btcTx.outs[swap.vout];
+            const ourOutput = swap.btcTx.outs[swap.vout];
 
-        const resp = await this.bitcoin.drainAll(swap.refundAddress, [{
-            type: this.bitcoin.getAddressType(),
-            confirmations: swap.btcTx.confirmations,
-            outputScript: Buffer.from(ourOutput.scriptPubKey.hex, "hex"),
-            value: ourOutput.value,
-            txId: swap.btcTx.txid,
-            vout: swap.vout
-        }], feeRate);
+            const resp = await this.bitcoin.drainAll(swap.refundAddress, [{
+                type: this.bitcoin.getAddressType(),
+                confirmations: swap.btcTx.confirmations,
+                outputScript: Buffer.from(ourOutput.scriptPubKey.hex, "hex"),
+                value: ourOutput.value,
+                txId: swap.btcTx.txid,
+                vout: swap.vout
+            }], feeRate);
 
-        if(resp==null) {
-            this.swapLogger.error(swap, "refundSwap(): cannot refund swap because of dust limit, txId: "+swap.txId);
+            if(resp==null) {
+                this.swapLogger.error(swap, "refundSwap(): cannot refund swap because of dust limit, txId: "+swap.txId);
+                unlock();
+                return;
+            }
+
+            if(swap.metadata!=null) swap.metadata.times.refundSignPSBT = Date.now();
+            this.swapLogger.debug(swap, "refundSwap(): signed raw transaction: "+resp.raw);
+
+            const refundTxId = resp.txId;
+            swap.refundTxId = refundTxId;
+
+            //Send the refund TX
+            await this.bitcoin.sendRawTransaction(resp.raw);
+            this.swapLogger.debug(swap, "refundSwap(): sent refund transaction: "+refundTxId);
+
+            this.refundedSwaps.set(swap.getIdentifierHash(), refundTxId);
+            await this.removeSwapData(swap, FromBtcTrustedSwapState.REFUNDED);
+        } finally {
             unlock();
-            return;
         }
-
-        if(swap.metadata!=null) swap.metadata.times.refundSignPSBT = Date.now();
-        this.swapLogger.debug(swap, "refundSwap(): signed raw transaction: "+resp.raw);
-
-        const refundTxId = resp.txId;
-        swap.refundTxId = refundTxId;
-
-        //Send the refund TX
-        await this.bitcoin.sendRawTransaction(resp.raw);
-        this.swapLogger.debug(swap, "refundSwap(): sent refund transaction: "+refundTxId);
-
-        this.refundedSwaps.set(swap.getIdentifierHash(), refundTxId);
-        await this.removeSwapData(swap, FromBtcTrustedSwapState.REFUNDED);
-        unlock();
     }
 
     private async burn(swap: FromBtcTrustedSwap) {
@@ -293,10 +296,27 @@ export class FromBtcTrusted extends SwapHandler<FromBtcTrustedSwap, FromBtcTrust
 
             if(swap.state!==FromBtcTrustedSwapState.BTC_CONFIRMED) return;
 
+            const txns = await chainInterface.txsTransfer(signer.getAddress(), swap.token, swap.adjustedOutput, swap.dstAddress);
+
             let unlock = swap.lock(30*1000);
             if(unlock==null) return;
 
-            const txns = await chainInterface.txsTransfer(signer.getAddress(), swap.token, swap.adjustedOutput, swap.dstAddress);
+            const pluginCheckResult = await PluginManager.onHandlePreFromBtcExecute(
+                SwapHandlerType.FROM_BTC_TRUSTED,
+                swap
+            );
+            if(isQuoteThrow(pluginCheckResult)) {
+                this.swapLogger.error(swap, "processPastSwap(): Error, got negative response from plugin: ", pluginCheckResult);
+                await this.refundSwap(swap);
+                unlock();
+                return;
+            }
+
+            if(swap.state!==FromBtcTrustedSwapState.BTC_CONFIRMED) {
+                unlock();
+                return;
+            }
+
             await chainInterface.sendAndConfirm(signer, txns, true, null, false, async (txId: string, rawTx: string) => {
                 swap.txIds = {init: txId};
                 swap.scRawTx = rawTx;

--- a/src/swaps/trusted/frombtc_trusted/FromBtcTrustedSwap.ts
+++ b/src/swaps/trusted/frombtc_trusted/FromBtcTrustedSwap.ts
@@ -183,4 +183,8 @@ export class FromBtcTrustedSwap extends SwapHandlerSwap<FromBtcTrustedSwapState>
         return createHash("sha256").update(this.btcAddress).digest().toString("hex");
     }
 
+    getDestinationAddress(): string {
+        return this.dstAddress;
+    }
+
 }

--- a/src/swaps/trusted/frombtcln_trusted/FromBtcLnTrusted.ts
+++ b/src/swaps/trusted/frombtcln_trusted/FromBtcLnTrusted.ts
@@ -16,7 +16,8 @@ import {
     LightningNetworkInvoice
 } from "../../../wallets/ILightningWallet";
 import {FromBtcAmountAssertions} from "../../assertions/FromBtcAmountAssertions";
-import { LightningAssertions } from "../../assertions/LightningAssertions";
+import {LightningAssertions} from "../../assertions/LightningAssertions";
+import {isQuoteThrow} from "../../../plugins/IPlugin";
 
 export type SwapForGasServerConfig = SwapBaseConfig & {
     minCltv: bigint,
@@ -226,6 +227,24 @@ export class FromBtcLnTrusted extends SwapHandler<FromBtcLnTrustedSwap, FromBtcL
 
             let unlock = invoiceData.lock(Infinity);
             if(unlock==null) return;
+
+            const pluginCheckResult = await PluginManager.onHandlePreFromBtcExecute(
+                SwapHandlerType.FROM_BTCLN_TRUSTED,
+                invoiceData
+            );
+            if(isQuoteThrow(pluginCheckResult)) {
+                await this.cancelSwapAndInvoice(invoiceData);
+                unlock();
+                throw {
+                    code: 29999,
+                    msg: pluginCheckResult.message
+                };
+            }
+
+            if(invoiceData.state!==FromBtcLnTrustedSwapState.RECEIVED) {
+                unlock();
+                return;
+            }
 
             const result = await chainInterface.sendAndConfirm(signer, txns, true, null, false, async (txId: string, rawTx: string) => {
                 invoiceData.txIds = {init: txId};

--- a/src/swaps/trusted/frombtcln_trusted/FromBtcLnTrustedSwap.ts
+++ b/src/swaps/trusted/frombtcln_trusted/FromBtcLnTrustedSwap.ts
@@ -118,4 +118,8 @@ export class FromBtcLnTrustedSwap extends SwapHandlerSwap<FromBtcLnTrustedSwapSt
         return createHash("sha256").update(Buffer.from(this.secret, "hex")).digest().toString("hex");
     }
 
+    getDestinationAddress(): string {
+        return this.dstAddress;
+    }
+
 }


### PR DESCRIPTION
- Adds new `onHandlePreToBtcExecute` and `onHandlePreFromBtcExecute` plugin handles
- The `InfoHandler` now supports returning contract version for a given chain
- Fixed plugin typeguards throwing on `null` values
- Fixed LP transitioning the client-side SDK to `PR_PAID` state too soon for LN -> Smart chain swaps