### PR TITLE
Fix CoinGecko price scale (mSat → µSat)

### DIFF
--- a/src/prices/CoinGeckoSwapPrice.ts
+++ b/src/prices/CoinGeckoSwapPrice.ts
@@ -27,7 +27,7 @@ export class CoinGeckoSwapPrice extends ISwapPrice<{coinId: string, decimals: nu
     }
 
     /**
-     * Returns coin price in µSat (sats-per-token * 1_000_000)
+     * Returns coin price in uSat (sats-per-token * 1_000_000)
      *
      * @param coin
      */

--- a/src/prices/CoinGeckoSwapPrice.ts
+++ b/src/prices/CoinGeckoSwapPrice.ts
@@ -27,7 +27,7 @@ export class CoinGeckoSwapPrice extends ISwapPrice<{coinId: string, decimals: nu
     }
 
     /**
-     * Returns coin price in mSat
+     * Returns coin price in µSat (sats-per-token * 1_000_000)
      *
      * @param coin
      */
@@ -35,7 +35,7 @@ export class CoinGeckoSwapPrice extends ISwapPrice<{coinId: string, decimals: nu
         const coinId = coin.coinId;
         if(coinId.startsWith("$fixed-")) {
             const amt: number = parseFloat(coinId.substring(7));
-            return BigInt(Math.floor(amt*1000));
+            return BigInt(Math.floor(amt*1000000));
         }
 
         const cachedValue = this.cache[coinId];
@@ -62,7 +62,7 @@ export class CoinGeckoSwapPrice extends ISwapPrice<{coinId: string, decimals: nu
 
         const amt: number = jsonBody[coinId].sats;
 
-        const result = BigInt(Math.floor(amt*1000));
+        const result = BigInt(Math.floor(amt*1000000));
 
         this.cache[coinId] = {
             price: result,

--- a/src/prices/ISwapPrice.ts
+++ b/src/prices/ISwapPrice.ts
@@ -13,7 +13,7 @@ export abstract class ISwapPrice<T extends {decimals: number} = {decimals: numbe
     }
 
     /**
-     * Returns coin price in mSat
+     * Returns coin price in µSat (sats-per-token * 1_000_000)
      *
      * @param tokenData
      */

--- a/src/prices/ISwapPrice.ts
+++ b/src/prices/ISwapPrice.ts
@@ -13,7 +13,7 @@ export abstract class ISwapPrice<T extends {decimals: number} = {decimals: numbe
     }
 
     /**
-     * Returns coin price in µSat (sats-per-token * 1_000_000)
+     * Returns coin price in uSat (sats-per-token * 1_000_000)
      *
      * @param tokenData
      */


### PR DESCRIPTION
Fixes #24.

`CoinGeckoSwapPrice.getPrice` scaled prices by `×1000` (mSat), but the `ISwapPrice` base-class conversions and the `Binance`/`OKX` providers use **µSat** (`sats-per-token × 1_000_000`). CoinGecko therefore returned prices **1000× too small**.

This is **Option A** from #24 — align to the live production (µSat) behavior:

- `CoinGeckoSwapPrice`: `×1000 → ×1000000` in both the `$fixed` and live branches.
- Docstrings: `ISwapPrice.getPrice` and `CoinGeckoSwapPrice.getPrice` — `"mSat"` → `"µSat (sats-per-token * 1_000_000)"`.

`Binance`/`OKX` are unchanged (already correct).

### Note on impact

CoinGecko isn't selectable from the LP node (`PRICE_SOURCE` accepts only `binance`/`okx`), so there's no live production impact — this removes a latent landmine and corrects the misleading docstring that caused it.

### Verification

`npm run build` (tsc 4.9) passes clean.
